### PR TITLE
Delete all identities when user is deleted

### DIFF
--- a/lib/coherence_assent/schema.ex
+++ b/lib/coherence_assent/schema.ex
@@ -80,7 +80,7 @@ defmodule CoherenceAssent.Schema do
   """
   defmacro coherence_assent_schema do
     quote do
-      has_many :user_identities, CoherenceAssent.UserIdentities.UserIdentity, foreign_key: :user_id
+      has_many :user_identities, CoherenceAssent.UserIdentities.UserIdentity, foreign_key: :user_id, on_delete: :delete_all
     end
   end
 end

--- a/test/coherence_assent/schema_test.exs
+++ b/test/coherence_assent/schema_test.exs
@@ -20,4 +20,17 @@ defmodule CoherenceAssent.SchemaTest do
       refute changeset.valid?
     end
   end
+
+  describe "Repo.delete/1" do
+    test "removes all identities", %{user: user} do
+      fixture(:user_identity, user, %{provider: "test_provider", uid: "1"})
+      fixture(:user_identity, user, %{provider: "test_provider", uid: "2"})
+
+      assert length(CoherenceAssent.repo.all(CoherenceAssent.UserIdentities.UserIdentity)) == 2
+
+      CoherenceAssent.repo.delete(user)
+
+      assert length(CoherenceAssent.repo.all(CoherenceAssent.UserIdentities.UserIdentity)) == 0
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/danschultzer/coherence_assent/issues/4#issuecomment-365028989

This will add `on_delete: :delete_all` for resource owner `user_identities`.