### PR TITLE
Make it possible to use a custom table name

### DIFF
--- a/lib/coherence_assent/user_identities/user_identity.ex
+++ b/lib/coherence_assent/user_identities/user_identity.ex
@@ -3,7 +3,9 @@ defmodule CoherenceAssent.UserIdentities.UserIdentity do
 
   use Ecto.Schema
 
-  schema "user_identities" do
+  @schema_name Application.get_env(:coherence_assent, :user_identity_schema_name, "user_identities")
+
+  schema @schema_name do
     belongs_to :user, Coherence.Config.user_schema
 
     field :provider,     :string,     null: false


### PR DESCRIPTION
This makes it possible to use a custom table name for the UserIdentity schema, by setting the config variable:

```elixir
config :coherence_assent,
  user_identity_schema_name: "custom_user_identies"
```