### PR TITLE
Fix facebook auth

### DIFF
--- a/lib/coherence_assent/strategies/facebook.ex
+++ b/lib/coherence_assent/strategies/facebook.ex
@@ -6,6 +6,8 @@ defmodule CoherenceAssent.Strategy.Facebook do
   alias CoherenceAssent.Strategy.Helpers
   alias CoherenceAssent.Strategy.OAuth2, as: OAuth2Helper
 
+  @api_version "2.12"
+
   @spec authorize_url(Conn.t, Keyword.t) :: {:ok, %{conn: Conn.t, url: String.t}}
   def authorize_url(conn, config) do
     OAuth2Helper.authorize_url(conn, set_config(config))
@@ -20,8 +22,7 @@ defmodule CoherenceAssent.Strategy.Facebook do
     state
     |> OAuth2Helper.check_state(client, params)
     |> OAuth2Helper.get_access_token(config, params)
-    |> add_client_params(config)
-    |> OAuth2Helper.get_user(config[:user_url])
+    |> get_user(config)
     |> normalize(client)
     |> case do
       {:ok, user} -> {:ok, %{conn: conn, client: client, user: user}}
@@ -31,8 +32,8 @@ defmodule CoherenceAssent.Strategy.Facebook do
 
   defp set_config(config) do
     [
-      site: "https://graph.facebook.com/v2.6",
-      authorize_url: "https://www.facebook.com/v2.6/dialog/oauth",
+      site: "https://graph.facebook.com/v#{@api_version}",
+      authorize_url: "https://www.facebook.com/v#{@api_version}/dialog/oauth",
       token_url: "/oauth/access_token",
       user_url: "/me",
       authorization_params: [scope: "email"],
@@ -42,14 +43,14 @@ defmodule CoherenceAssent.Strategy.Facebook do
     |> Keyword.put(:strategy, OAuth2.Strategy.AuthCode)
   end
 
-  defp add_client_params({:ok, client}, config) do
-    client = client
-    |> OAuth2.Client.put_param(:appsecret_proof, appsecret_proof(client))
-    |> OAuth2.Client.put_param(:fields, config[:user_url_request_fields])
+  defp get_user({:ok, client}, config) do
+    params = %{"appsecret_proof" => appsecret_proof(client),
+               "fields" => config[:user_url_request_fields]}
+    user_url = config[:user_url] <> "?" <> URI.encode_query(params)
 
-    {:ok, client}
+    OAuth2Helper.get_user({:ok, client}, user_url)
   end
-  defp add_client_params({:error, error}, _config), do: {:error, error}
+  defp get_user({:error, error}, _config), do: {:error, error}
 
   defp normalize({:ok, user}, client) do
     user = %{"uid"         => user["id"],
@@ -77,6 +78,6 @@ defmodule CoherenceAssent.Strategy.Facebook do
   defp appsecret_proof(client) do
     :sha256
     |> :crypto.hmac(client.client_secret, client.token.access_token)
-    |> Base.encode16()
+    |> Base.encode16(case: :lower)
   end
 end

--- a/test/coherence_assent/strategies/vk_test.exs
+++ b/test/coherence_assent/strategies/vk_test.exs
@@ -30,15 +30,18 @@ defmodule CoherenceAssent.VKTest do
 
     test "normalizes data", %{conn: conn, config: config, params: params, bypass: bypass} do
       Bypass.expect_once bypass, "POST", "/access_token", fn conn ->
+        assert {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        assert body =~ "scope=email"
+
         send_resp(conn, 200, Poison.encode!(%{"access_token" => "access_token", "email" => "lindsay.stirling@example.com"}))
       end
 
       Bypass.expect_once bypass, "GET", "/method/users.get", fn conn ->
-        query = Plug.Conn.fetch_query_params(conn)
+        conn = Plug.Conn.fetch_query_params(conn)
 
-        assert query.params["fields"] == "uid,first_name,last_name,photo_200,screen_name,verified"
-        assert query.params["v"] == "5.69"
-        assert query.params["access_token"] == "access_token"
+        assert conn.params["fields"] == "uid,first_name,last_name,photo_200,screen_name,verified"
+        assert conn.params["v"] == "5.69"
+        assert conn.params["access_token"] == "access_token"
 
         users = [%{"id" => 210700286,
                    "first_name" => "Lindsay",


### PR DESCRIPTION
For whatever reason Facebook wasn't actually working (ever [since 2.4](https://developers.facebook.com/docs/graph-api/changelog/archive#v2_4_new_features) the `fields` param has been necessary). It didn't pull the email. This has been resolved now, and I've also added better tests for VK to make sure the right fields are received by VK.com.